### PR TITLE
Updated lustre-local-pvc NOT to use default storageClass gp2

### DIFF
--- a/pv.tf
+++ b/pv.tf
@@ -61,6 +61,7 @@ resource "kubernetes_persistent_volume_claim" "lustre_local_pvc" {
         storage = "${var.lustre_storage_capacity}Gi"
       }
     }
-    volume_name = kubernetes_persistent_volume.lustre_local_pv.metadata[0].name
+    volume_name        = kubernetes_persistent_volume.lustre_local_pv.metadata[0].name
+    storage_class_name = ""
   }
 }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,6 +1,6 @@
 region             = "us-east-1"
 bucket_name        = "lab-hpc-se-hpc-1-storage"
 filesystem_version = "2.12"
-pv_name            = "lustr-local-pv-2-12"
-pvc_name           = "lustr-local-pvc-2-12"
+pv_name            = "lustre-local-pv-2-12"
+pvc_name           = "lustre-local-pvc-2-12"
 app_namespace      = "lustre-app"


### PR DESCRIPTION
Updated lustre-local-pvc NOT to use default storageClass gp2